### PR TITLE
Fix: Using magic number instead of constans in templates

### DIFF
--- a/build/lib/template/partial/message.hbs
+++ b/build/lib/template/partial/message.hbs
@@ -16,7 +16,7 @@
             {{~#is this.hasClearMethodCreated false~}}
 {{{indent}}}    {{printClearIfNotPresent this}}
             {{/is}}
-            {{~#is this.type BYTES_TYPE~}}
+            {{~#is this.type 12~}}
 {{{indent}}}    get{{{this.camelUpperName}}}List(): Array<Uint8Array | string>;
 {{{indent}}}    get{{{this.camelUpperName}}}List_asU8(): Array<Uint8Array>;
 {{{indent}}}    get{{{this.camelUpperName}}}List_asB64(): Array<string>;
@@ -28,7 +28,7 @@
 {{{indent}}}    {{printRepeatedAddMethod this this.exportType}}
             {{~/is~}}
         {{~else~}}{{!-- repeat else --}}
-            {{~#is this.type BYTES_TYPE~}}
+            {{~#is this.type 12~}}
 {{{indent}}}    get{{{this.camelUpperName}}}(): Uint8Array | string;
 {{{indent}}}    get{{{this.camelUpperName}}}_asU8(): Uint8Array;
 {{{indent}}}    get{{{this.camelUpperName}}}_asB64(): string;
@@ -64,13 +64,13 @@
 {{{indent}}}        {{{this.camelCaseName}}}Map: Array<[{{{this.mapFieldInfo.keyTypeName}}}{{~#is this.mapFieldInfo.keyType MESSAGE_TYPE~}}.AsObject{{~/is~}}, {{{this.mapFieldInfo.valueTypeName}}}{{~#is this.mapFieldInfo.valueType MESSAGE_TYPE~}}.AsObject{{~/is~}}]>,
     {{~else~}}{{!-- map spec else --}}
         {{~#if this.isRepeatField~}}{{!-- repeat start --}}
-            {{~#is this.type BYTES_TYPE~}}
+            {{~#is this.type 12~}}
 {{{indent}}}        {{{this.camelCaseName}}}List: Array<Uint8Array | string>,
             {{~else~}}
 {{{indent}}}        {{{this.camelCaseName}}}List: Array<{{{this.exportType}}}{{~#is this.type MESSAGE_TYPE~}}.AsObject{{~/is~}}>,
             {{~/is~}}
         {{else}}{{!-- repeat else --}}
-            {{~#is this.type BYTES_TYPE~}}
+            {{~#is this.type 12~}}
 {{{indent}}}        {{{this.camelCaseName}}}: Uint8Array | string,
             {{~else~}}
 {{{indent}}}        {{{this.camelCaseName}}}{{~#if this.canBeUndefined~}}?{{~/if~}}: {{{this.fieldObjectType}}},

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "grpc_tools_node_protoc_ts",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "lockfileVersion": 1,
   "dependencies": {
     "@protobufjs/aspromise": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grpc_tools_node_protoc_ts",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Generate d.ts definitions for generated js files from grpc_tools_node_protoc",
   "main": "build/index.js",
   "scripts": {

--- a/src/lib/template/partial/message.hbs
+++ b/src/lib/template/partial/message.hbs
@@ -16,7 +16,7 @@
             {{~#is this.hasClearMethodCreated false~}}
 {{{indent}}}    {{printClearIfNotPresent this}}
             {{/is}}
-            {{~#is this.type BYTES_TYPE~}}
+            {{~#is this.type 12~}}
 {{{indent}}}    get{{{this.camelUpperName}}}List(): Array<Uint8Array | string>;
 {{{indent}}}    get{{{this.camelUpperName}}}List_asU8(): Array<Uint8Array>;
 {{{indent}}}    get{{{this.camelUpperName}}}List_asB64(): Array<string>;
@@ -28,7 +28,7 @@
 {{{indent}}}    {{printRepeatedAddMethod this this.exportType}}
             {{~/is~}}
         {{~else~}}{{!-- repeat else --}}
-            {{~#is this.type BYTES_TYPE~}}
+            {{~#is this.type 12~}}
 {{{indent}}}    get{{{this.camelUpperName}}}(): Uint8Array | string;
 {{{indent}}}    get{{{this.camelUpperName}}}_asU8(): Uint8Array;
 {{{indent}}}    get{{{this.camelUpperName}}}_asB64(): string;
@@ -64,13 +64,13 @@
 {{{indent}}}        {{{this.camelCaseName}}}Map: Array<[{{{this.mapFieldInfo.keyTypeName}}}{{~#is this.mapFieldInfo.keyType MESSAGE_TYPE~}}.AsObject{{~/is~}}, {{{this.mapFieldInfo.valueTypeName}}}{{~#is this.mapFieldInfo.valueType MESSAGE_TYPE~}}.AsObject{{~/is~}}]>,
     {{~else~}}{{!-- map spec else --}}
         {{~#if this.isRepeatField~}}{{!-- repeat start --}}
-            {{~#is this.type BYTES_TYPE~}}
+            {{~#is this.type 12~}}
 {{{indent}}}        {{{this.camelCaseName}}}List: Array<Uint8Array | string>,
             {{~else~}}
 {{{indent}}}        {{{this.camelCaseName}}}List: Array<{{{this.exportType}}}{{~#is this.type MESSAGE_TYPE~}}.AsObject{{~/is~}}>,
             {{~/is~}}
         {{else}}{{!-- repeat else --}}
-            {{~#is this.type BYTES_TYPE~}}
+            {{~#is this.type 12~}}
 {{{indent}}}        {{{this.camelCaseName}}}: Uint8Array | string,
             {{~else~}}
 {{{indent}}}        {{{this.camelCaseName}}}{{~#if this.canBeUndefined~}}?{{~/if~}}: {{{this.fieldObjectType}}},


### PR DESCRIPTION
.. due to constants in templates can not be recognized by the template engine.

This will produce incorrect `bytes` fields `.d.ts` files if using constans because template engine treat them as strings.