### PR TITLE
Use bool const type for rpc type

### DIFF
--- a/src/lib/template/svc_tsd.hbs
+++ b/src/lib/template/svc_tsd.hbs
@@ -18,8 +18,8 @@ interface I{{{serviceName}}}Service extends grpc.ServiceDefinition<grpc.UntypedS
     {{#each methods}}
 interface I{{{serviceName}}}Service_I{{{methodName}}} extends grpc.MethodDefinition<{{{requestTypeName}}}, {{{responseTypeName}}}> {
     path: string; // "/{{{packageName}}}.{{{serviceName}}}/{{{methodName}}}"
-    requestStream: boolean; // {{{requestStream}}}
-    responseStream: boolean; // {{{responseStream}}}
+    requestStream: {{{requestStream}}};
+    responseStream: {{{responseStream}}};
     requestSerialize: grpc.serialize<{{{requestTypeName}}}>;
     requestDeserialize: grpc.deserialize<{{{requestTypeName}}}>;
     responseSerialize: grpc.serialize<{{{responseTypeName}}}>;


### PR DESCRIPTION
Uses const types for `requestStream` and `responseStream`, either `true`
or `false` types instead of generic `boolean` TS types allowing advanced
call type inference from the service definition.

Higher abstraction framework libraries, such as
https://github.com/malijs/mali could leverage advanced type inference to
hint/check specific type handlers if this information would be part of
the type rpc service type definition.

At this point, the only way to determine thy type of RPC is using
`I{{{serviceName}}}Server` interface, which must be linked manually to
`I{{{serviceName}}}Service` methods. For registring handlers at runtime,
only e.g. `GreeterService` and corresponding implementation is required,
manually adding `IGreeterServer` is possible, but troublesome. This
would not be required if rpc type could be inferred using the const
booleans to define the type.

This change does is not a breaking change and the const boolean types
are working correctly since the oldest available version on TS
playground 2.4.1. See playground link in the trailers.

There are no obvoius disadvantages to using const booleans and change
could potentially give node grpc frameworks more power for sophisticated
type inference.

There are no tests in the project, but so at least I tried it manually
with `npm link` on a custom project and it behaves as expected.

See: https://www.typescriptlang.org/play/?ts=2.4.1#code/MYewdgzgLgBAhsYBTADlAKgJwK5JgXhgAoA3OAGwC4YockBKAgPhjPIChRJYFk0AxChDyFSFagDMhDZqwrt2vVBjpEp5YfUWJlgjUjXStStFlxFauYzoHSLdekA