### PR TITLE
Add ClientOptions in constructor for grpc-js clients

### DIFF
--- a/src/lib/template/svc_tsd.hbs
+++ b/src/lib/template/svc_tsd.hbs
@@ -76,7 +76,11 @@ export interface I{{{serviceName}}}Client {
 }
 
 export class {{{serviceName}}}Client extends grpc.Client implements I{{{serviceName}}}Client {
+    {{#if (fetchIsGrpcJs)}}
+    constructor(address: string, credentials: grpc.ChannelCredentials, options?: Partial<grpc.ClientOptions>);
+    {{else}}
     constructor(address: string, credentials: grpc.ChannelCredentials, options?: object);
+    {{/if}}
     {{#each methods}}
         {{#eq type "ClientUnaryCall"}}
     public {{lcFirst methodName}}(request: {{{requestTypeName}}}, callback: (error: grpc.ServiceError | null, response: {{{responseTypeName}}}) => void): grpc.ClientUnaryCall;


### PR DESCRIPTION
The `@grpc/grpc-js` has types for the options in client constructors, this template change conditionally adds these types to generated constructors.