### PR TITLE
Add ".npmignore" to remove examples and bash scripts from npm library

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+examples
+bash


### PR DESCRIPTION
The size of the npm package for this project is HUGE because the "examples" are being included.

This PR adds an .npmignore to exclude the "examples" and "bash" folders from being published to NPM.

This shrinks the size of the dependency to only a few KB (when it is normally over 40mb)