### PR TITLE
Use string literal type for path

### DIFF
--- a/src/lib/template/svc_tsd.hbs
+++ b/src/lib/template/svc_tsd.hbs
@@ -17,7 +17,7 @@ interface I{{{serviceName}}}Service extends grpc.ServiceDefinition<grpc.UntypedS
 
     {{#each methods}}
 interface I{{{serviceName}}}Service_I{{{methodName}}} extends grpc.MethodDefinition<{{{requestTypeName}}}, {{{responseTypeName}}}> {
-    path: string; // "/{{{packageName}}}{{#if packageName}}.{{/if}}{{{serviceName}}}/{{{methodName}}}"
+    path: "/{{{packageName}}}{{#if packageName}}.{{/if}}{{{serviceName}}}/{{{methodName}}}";
     requestStream: {{{requestStream}}};
     responseStream: {{{responseStream}}};
     requestSerialize: grpc.serialize<{{{requestTypeName}}}>;

--- a/src/lib/template/svc_tsd.hbs
+++ b/src/lib/template/svc_tsd.hbs
@@ -17,7 +17,7 @@ interface I{{{serviceName}}}Service extends grpc.ServiceDefinition<grpc.UntypedS
 
     {{#each methods}}
 interface I{{{serviceName}}}Service_I{{{methodName}}} extends grpc.MethodDefinition<{{{requestTypeName}}}, {{{responseTypeName}}}> {
-    path: string; // "/{{{packageName}}}.{{{serviceName}}}/{{{methodName}}}"
+    path: string; // "/{{{packageName}}}{{#if packageName}}.{{/if}}{{{serviceName}}}/{{{methodName}}}"
     requestStream: {{{requestStream}}};
     responseStream: {{{responseStream}}};
     requestSerialize: grpc.serialize<{{{requestTypeName}}}>;


### PR DESCRIPTION
I kept the two commits in the same PR. Though they are not directly semantically related, they change the same lines and would trigger conflicts. If it is desirable as two PRs, I can update it.

## Use type literal for path

Using string literal type _should_ not break anything (tested on a
larger project) since it is a subtype of string.

Using literal instead of generic string allows to do type-safe
RPC matching, for example it generic middlewares for cache, ACL etc.
Without it we need to match a string for path (long, prone to errors) or
method names (ambiguous) and have no way to check, wheather the matching
is correct or not.

With literals, we can extract all paths from generated stubs with
meta-typing and use it in these occasions.

## Fix path composition on missing package

Correct RPC paths (also aligned with the grpc implementation) are
- `/Package.Service/Method`
- `/Service/Method` (undefined package)

Currently the template does not handle well services without package
- `/Package.Service/Method` white_check_mark
- `/.Service/Method` x (extra dot)

This commit adds the dot conditionally only if Package is not falsy