### PR TITLE
Bump DefinitelyTyped version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "handlebars-helpers": "0.10.0"
   },
   "devDependencies": {
-    "@types/google-protobuf": "3.7.2",
+    "@types/google-protobuf": "3.7.4",
     "@types/node": "14.14.16",
     "tslint": "5.9.1",
     "typescript": "4.1.3"


### PR DESCRIPTION
This PR bumps the DefinitelyTyped package version to the latest. This should hopefully fix some issues with type definitions for, among other things, the Timestamp type.