### PR TITLE
updating readme instructions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ npm install grpc_tools_node_protoc_ts --save-dev
 # generate js codes via grpc-tools
 grpc_tools_node_protoc \
 --js_out=import_style=commonjs,binary:./your_dest_dir \
---grpc_out=./your_dest_dir \
+--grpc_out=grpc_js:./your_dest_dir \
 --plugin=protoc-gen-grpc=`which grpc_tools_node_protoc_plugin` \
 -I ./proto \
 ./your_proto_dir/*.proto
@@ -79,7 +79,7 @@ grpc_tools_node_protoc \
 # generate d.ts codes
 protoc \
 --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts \
---ts_out=./your_dest_dir \
+--ts_out=grpc_js:./your_dest_dir \
 -I ./proto \
 ./your_proto_dir/*.proto
 ```


### PR DESCRIPTION
Although the option `grpc_js` has been introduced in the version `v1.9.0`, the read me file was still missing this option as the default command. 

And, although this option is not mandatory, without this option the generated code will throw alerts about using the `grpc` library because it is deprecating.
