### PR TITLE
Add bin script for Windows system

### DIFF
--- a/bin/protoc-gen-ts.cmd
+++ b/bin/protoc-gen-ts.cmd
@@ -1,0 +1,8 @@
+@echo off
+
+setlocal
+
+cd "%~dp0"
+node.exe -e "var LibPath = require('path'); require(LibPath.join(__dirname, '../build/index'));"
+
+endlocal


### PR DESCRIPTION
Add bin script for Windows system.

Then it can be used like:

_--plugin=protoc-gen-ts=C:\somepath\bin\protoc-gen-ts.cmd_